### PR TITLE
[sdk-manage] Fix usage outside of home directory. Contribute to JB#39655

### DIFF
--- a/sdk-setup/src/sdk-manage
+++ b/sdk-setup/src/sdk-manage
@@ -90,6 +90,12 @@ fi
 ################################################################'
 # Common utilities
 
+# When sb2 is used outside of home directory CWD mapping may not be possible.
+# This would break e.g. `sdk-manage target install <pkg>` when invoked outside
+# of home directory - zypper would fail.  The `cd` is intentionally
+# unconditional, so that eventual issues are discovered ASAP.
+sb2() ( cd; command sb2 "$@" )
+
 print_array() {
     local array=("$@")
     declare -p array |sed 's/^[^=]*=//'


### PR DESCRIPTION
This has been broken since commit
8c798b0bd888943cfdf6622e41eafc8b8a7d491f ([sdk-manage] Eliminate
--use-chroot-as option) - 'sudo -i' has the effect of 'cd'.