### PR TITLE
[sdk-manage] Fix usage outside of home directory. Contribute to JB#39655

### DIFF
--- a/sdk-setup/src/sdk-manage
+++ b/sdk-setup/src/sdk-manage
@@ -66,6 +66,11 @@ set -u
 # Make sure normal users can use any dirs we make
 umask 022
 
+# When sb2 is used outside of home directory CWD mapping may not be possible.
+# This would break e.g. `sdk-manage target install <pkg>` when invoked outside
+# of home directory - zypper would fail.  The `cd` is intentionally
+# unconditional, so that eventual issues are discovered ASAP.
+sb2() ( cd; command sb2 "$@" )
 
 ################################################################'
 # toolchain


### PR DESCRIPTION
This has been broken since commit
8c798b0bd888943cfdf6622e41eafc8b8a7d491f ([sdk-manage] Eliminate
--use-chroot-as option) - 'sudo -i' has the effect of 'cd'.

(adapted from commit 965e901de680b2820e7d91959a37622bd59d4601)