### PR TITLE
Prevent ConnMan setting an invalid gateway

### DIFF
--- a/sdk-setup/src/sdk-setup-enginelan
+++ b/sdk-setup/src/sdk-setup-enginelan
@@ -65,7 +65,8 @@ Description = SDK Engine Configuration
 
 [service_sailfishsdk_ethernet]
 Type = ethernet
-IPv4 = $subnet.254/24/0.0.0.0
+# TODO: The desired effect here is to prevent connman setting gateway - how to do that properly?
+IPv4 = $subnet.254/24/$subnet.253
 IPv6 = off
 MAC = 08:00:5A:11:F1:55
 


### PR DESCRIPTION
Using the SDK on a machine without internet connection available, the
original configuration led to default gateway being set for this
interface, which is the interface connected to the virtual network for
communication between build engine and emulator. I haven't found a
better way to fix this. Tried reordering the services, using
AlwaysConnectedTechnologies and EnableOnlineCheck config options and
more, with no effect.