### PR TITLE
[mer-sdk-chroot] Make bind mounts more robust. Contributes to JB#27928

### DIFF
--- a/sdk-setup/src/mer-sdk-chroot
+++ b/sdk-setup/src/mer-sdk-chroot
@@ -189,12 +189,40 @@ umask 022
 
 ################################################################
 # Mount
+
+# In order to deal with varying status of adoption of changes to FHS among
+# distributions a list of alternate paths is considered for binding.
 mount_bind() {
-    if [[ ! -d ${sdkroot}$1 ]]; then
-	echo "Directory $1 is missing in SDK root - please report this bug"
-	mkdir -p ${sdkroot}$1
+    maybe_symlinks="$*"
+    src=""
+    dsts=""
+
+    for dir in $maybe_symlinks; do
+        if [[ -d $dir ]]; then
+            src="$dir"
+            break
+        fi
+    done
+
+    if [[ -z "$src" ]]; then
+        echo "mount_bind $*: None of these exists on your host - please report this bug"
+        return
     fi
-    mount --bind $1 ${sdkroot}$1
+
+    for dir in $maybe_symlinks; do
+        if [[ -e ${sdkroot}$dir && ! -L ${sdkroot}$dir ]]; then
+            dsts="$dsts $dir"
+        fi
+    done
+
+    if [[ -z "$dsts" ]]; then
+        echo "mount_bind $*: No non-symlink target in SDK root - please report this bug"
+        return
+    fi
+
+    for dst in $dsts; do
+        mount --bind $src ${sdkroot}$dst
+    done
 }
 prepare_mountpoints() {
     # This prevents the following mount_bind to hang first time after reboot.
@@ -207,7 +235,7 @@ prepare_mountpoints() {
     mount_bind /sys
     mount_bind /dev
     mount_bind /dev/pts
-    mount_bind /dev/shm
+    mount_bind /dev/shm /run/shm
     mount_bind /var/lib/dbus
     mount_bind /var/run/dbus
 


### PR DESCRIPTION
The main motivation for this is the issue with varying status of
moving from /dev/shm to /run/shm among distributions.

Signed-off-by: Martin Kampas <martin.kampas@jolla.com>