### PR TITLE
[sshd] Don't accept locale environment variables. Contribute to JB#43225

### DIFF
--- a/sdk-setup/etc/sshd_config_engine
+++ b/sdk-setup/etc/sshd_config_engine
@@ -91,9 +91,11 @@ ChallengeResponseAuthentication no
 UsePAM yes
 
 # Accept locale-related environment variables
-AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
-AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
-AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE
+# Build engine only has C, POSIX and en_US.utf8 locales defined, so forwarding
+# locale environment variables causes warnings
+# AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
+# AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
+# AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE
 AcceptEnv XMODIFIERS
 
 #AllowAgentForwarding yes


### PR DESCRIPTION
Build engine only has C, POSIX and en_US.utf8 locales defined. Forwarding
environment variables containing any other locales results in errors.