### PR TITLE
[documentation] Fix Platform SDK links. Fixes JB#45357

### DIFF
--- a/sdk-setup/src/mer-sdk-chroot
+++ b/sdk-setup/src/mer-sdk-chroot
@@ -13,7 +13,7 @@ usage()
            $0 -h
 
        This is the Mer chroot SDK.
-       For information see http://wiki.merproject.org/wiki/Platform_SDK
+       For information see https://sailfishos.org/wiki/Platform_SDK
 
       If command is not present,
          used to enter the SDK and begin working. The SDK bash shell is a

--- a/sdk-setup/systemd/information.service
+++ b/sdk-setup/systemd/information.service
@@ -3,7 +3,7 @@
 
 [Unit]
 Description=SDK Information
-Documentation=http://wiki.merproject.org/Platform_SDK
+Documentation=https://sailfishos.org/wiki/Platform_SDK
 After=systemd-user-sessions.service plymouth-quit-wait.service multi-user.target network.target
 
 [Service]

--- a/sdk-setup/systemd/resize-rootfs.service
+++ b/sdk-setup/systemd/resize-rootfs.service
@@ -3,7 +3,7 @@
 
 [Unit]
 Description=Resize rootfs
-Documentation=http://wiki.merproject.org/Platform_SDK
+Documentation=https://sailfishos.org/wiki/Platform_SDK
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Old broken links to http://wiki.merproject.org/Platform_SDK were
replaced with links to https://sailfishos.org/wiki/Platform_SDK