### PR TITLE
[mer-sdk-chroot] Fix invocation of dbus-uuidgen. Fixes JB#47723

### DIFF
--- a/sdk-setup/src/mer-sdk-chroot
+++ b/sdk-setup/src/mer-sdk-chroot
@@ -311,7 +311,7 @@ prepare_etc() {
 
 ensure_machine_id() {
     setarch i386 chroot ${sdkroot} /bin/systemd-machine-id-setup
-    setarch i386 chroot ${sdkroot} /bin/dbus-uuidgen --ensure
+    setarch i386 chroot ${sdkroot} /usr/bin/dbus-uuidgen --ensure
 }
 
 ################


### PR DESCRIPTION
Installation path changed with upgrade of dbus to 1.13.12