### PR TITLE
[mer-tooling-chroot] Fix resolv.conf copying. Fixes JB#49950

### DIFF
--- a/sdk-setup/src/mer-tooling-chroot
+++ b/sdk-setup/src/mer-tooling-chroot
@@ -52,7 +52,7 @@ fi
 ################################################################
 
 prepare_etc() {
-    cp -f --dereference /etc/resolv.conf ${toolingroot}/etc/resolv.conf
+    cp --remove-destination --dereference /etc/resolv.conf ${toolingroot}/etc/resolv.conf
 
     cat >${toolingroot}/etc/profile.d/90_prompt.sh <<END
 # Do not edit! Created by /$(basename $0)


### PR DESCRIPTION
Changed cp to use --remove-destination because -f refuses to overwrite
dangling symlinks.