### PR TITLE
[mb2] Treat 106 as successful return value for zypper. Fixes JB#46187

### DIFF
--- a/sdk-setup/src/mb2
+++ b/sdk-setup/src/mb2
@@ -1883,6 +1883,7 @@ run_deploy() {
             device_rpms=$(sed "s,^$OPT_OUTPUTDIR/,RPMS/," <<<"$rpms")
             ssh_as root zypper --non-interactive --quiet in -f ${device_rpms}
             retcode=$?
+            [[ $retcode -eq 106 ]] && retcode=0
             ssh_as root rm -f ${device_rpms}
             ;;
         --rsync )


### PR DESCRIPTION
zypper returns 106 when it has disabled some repository temporarily.
It does not mean that the installation had been unsuccessful.