### PR TITLE
[mb2] Ignore default ssh keys which require password. Fixes JB#50884

### DIFF
--- a/rpm/sdk-setup.spec
+++ b/rpm/sdk-setup.spec
@@ -203,6 +203,7 @@ cp src/sdk-init %{buildroot}%{_bindir}/
 mkdir -p %{buildroot}%{_libexecdir}/%{name}
 cp src/oomadvice %{buildroot}%{_libexecdir}/%{name}/
 cp src/sdk-setup-swap %{buildroot}%{_libexecdir}/%{name}/
+cp src/ssh-askpass %{buildroot}%{_libexecdir}/%{name}/
 mkdir -p %{buildroot}%{_datadir}/%{name}
 cp README.tips.wiki %{buildroot}%{_datadir}/%{name}/
 
@@ -349,6 +350,7 @@ fi
 %{_bindir}/sdk-init
 %{_libexecdir}/%{name}/oomadvice
 %{_libexecdir}/%{name}/sdk-setup-swap
+%{_libexecdir}/%{name}/ssh-askpass
 %config %{_sysconfdir}/ssh/ssh_config.sdk
 %config %{_sysconfdir}/bash_completion.d/mb2.bash
 %config %{_sysconfdir}/bash_completion.d/sdk-assistant.bash

--- a/sdk-setup/src/mb2
+++ b/sdk-setup/src/mb2
@@ -1120,6 +1120,11 @@ with_specific_or_default_keys() {
     fi
 
     add_specific_or_default_keys() {
+
+        ssh-add() {
+            DISPLAY=:0 SSH_ASKPASS=/usr/libexec/sdk-setup/ssh-askpass command ssh-add "$@"
+        } 
+
         local key=$1
         if [[ $key ]]; then
             ssh-add -q - <"$key" || return
@@ -1130,7 +1135,7 @@ with_specific_or_default_keys() {
             # genericlinuxdeviceconfigurationwizardpages.cpp
             for default_key in "$real_home"/.ssh/id_{rsa,ecdsa,ed25519}; do
                 if [[ -f $default_key ]]; then
-                    ssh-add -q - <"$default_key" # allow failure
+                    ssh-add -q - <"$default_key" || :
                 fi
             done
         fi

--- a/sdk-setup/src/ssh-askpass
+++ b/sdk-setup/src/ssh-askpass
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Dummy implementation of ssh-askpass
+#
+# Copyright (C) 2020  Open Mobile Platform LLC.
+# Contact: http://jolla.com/
+# All rights reserved.
+#
+# You may use this file under the terms of BSD license as follows:
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#   * Neither the name of the Jolla Ltd nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+echo "Warning: Use of password-protected SSH keys is not supported" >&2
+exit 1


### PR DESCRIPTION
If any of the default keys requires password, ssh-add would fail. Now
we print a warning instead.