### PR TITLE
[mb2] Use binary mode when applying patches. Fixes JB#49598

### DIFF
--- a/sdk-setup/src/mb2
+++ b/sdk-setup/src/mb2
@@ -1713,6 +1713,7 @@ run_apply() {
     fi
 
     tr -d '\r' < "$OPT_SPEC" > "$TMP_SPEC"
+    cmp -s "$OPT_SPEC" "TMP_SPEC" || common_op+=(--binary)
 
     local to_apply=
     local auto_applied=$(grep -q "^%autosetup" "$TMP_SPEC" \


### PR DESCRIPTION
By default, when patch notices CRLF line endings in patches, it removes
the CRs. As the files to be patched still have the CRLF line endings,
patch fails. Using binary mode disables the heuristics.