### PR TITLE
[sdk-manage] Run systemd-machine-id-setup twice if it fails. JB#52613

### DIFF
--- a/sdk-setup/src/sdk-manage
+++ b/sdk-setup/src/sdk-manage
@@ -681,7 +681,10 @@ init_machine_id() {
         enter "$type:$object" rm -f /var/lib/dbus/machine-id || return
     fi
 
-    enter "$type:$object" systemd-machine-id-setup || return
+    if ! enter "$type:$object" systemd-machine-id-setup; then
+        echo >&2 "NOTICE: systemd-machine-id-setup failed, retrying"
+        enter "$type:$object" systemd-machine-id-setup || return
+    fi
     enter "$type:$object" dbus-uuidgen --ensure || return
 }
 


### PR DESCRIPTION
In systemd v238 systemd-machine-id-setup thinks it fails if proc is not
mounted, even if writing machine-id actually succeeded. The second
invocation will correctly detect existing machine-id unless writing
machine-id actually failed.