### PR TITLE
[sdk-chroot] Rename mer-sdk-chroot to sdk-chroot. Fixes JB#56734

### DIFF
--- a/rpm/sdk-setup.spec
+++ b/rpm/sdk-setup.spec
@@ -22,7 +22,7 @@ Requires(pre): /bin/rm
 Conflicts:  sdk-vm
 
 %description -n sdk-chroot
-Contains the mer_sdk_chroot script and supporting configs
+Contains the sdk-chroot script and supporting configs
 
 %package -n sdk-vm
 Summary:    Mer SDK files for the VM variant
@@ -139,7 +139,8 @@ ln -s /var/cache/zypp %{buildroot}/home/.zypp-cache
 
 # sdk-chroot
 mkdir -p %{buildroot}/%{_sysconfdir}
-cp src/mer-sdk-chroot %{buildroot}/
+cp src/sdk-chroot %{buildroot}/
+ln -s sdk-chroot %{buildroot}/mer-sdk-chroot
 cp src/mer-bash-setup %{buildroot}/
 echo "This file serves for detection that this is a chroot SDK installation" > %{buildroot}/%{_sysconfdir}/mer-sdk-chroot
 mkdir -p %{buildroot}/srv/mer/targets
@@ -290,6 +291,7 @@ fi
 %files -n sdk-chroot
 %defattr(-,root,root,-)
 /mer-sdk-chroot
+/sdk-chroot
 /mer-bash-setup
 %{_bindir}/sdk-version
 /home/.zypp-cache

--- a/sdk-setup/src/sdk-chroot
+++ b/sdk-setup/src/sdk-chroot
@@ -1,10 +1,5 @@
 #!/bin/bash
-# mer-sdk-chroot
-
-# TODO
-#
-# Support a Mer clean setup (ie no .oscrc)
-# Support multiple shells (ie split setup/entry)
+# sdk-chroot
 
 usage()
 {
@@ -12,8 +7,8 @@ usage()
     usage: $0 [-u <user>] [-m <all|none|root|home>] [-r <SDK root path>] [<command> <args> ..]
            $0 -h
 
-       This is the Mer chroot SDK.
-       For information see https://sailfishos.org/wiki/Platform_SDK
+       This is the minimal, chroot-based Sailfish SDK.
+       For information see https://docs.sailfishos.org/Tools/Platform_SDK/
 
       If command is not present,
          used to enter the SDK and begin working. The SDK bash shell is a
@@ -344,12 +339,14 @@ run_user_hook() {
 retval=0
 cwd=$(pwd)
 
+[[ $0 = *mer-sdk-chroot ]] && echo "WARNING: mer-sdk-chroot is deprecated. Use sdk-chroot instead."
+
 # For back compatibility abort on 'mount/umount' and warn on 'enter' 
 if [[ $# == 1 ]]; then
     case $1 in
 	mount|umount )
 	    cat <<EOF
-ERROR: the mer-sdk-chroot command no longer needs or supports 'mount/umount/enter'
+ERROR: the sdk-chroot command no longer needs or supports 'mount/umount/enter'
 Just enter the SDK using:
  $0
 


### PR DESCRIPTION
The script still has several references to mer. Those will be handled in separate tasks.